### PR TITLE
fix: pass context to the key handler in the server wrapper

### DIFF
--- a/cmd/kms-server/main.go
+++ b/cmd/kms-server/main.go
@@ -49,7 +49,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	srv := server.NewServer(func(string) ([]byte, error) { return key, nil })
+	srv := server.NewServer(func(context.Context, string) ([]byte, error) { return key, nil })
 
 	s := grpc.NewServer()
 	kms.RegisterKMSServiceServer(s, srv)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,21 +24,21 @@ import (
 type Server struct {
 	kms.UnimplementedKMSServiceServer
 
-	getKey func(string) ([]byte, error)
+	getKey func(context.Context, string) ([]byte, error)
 }
 
 // NewServer initializes new server.
-func NewServer(keyHandler func(nodeUUID string) ([]byte, error)) *Server {
+func NewServer(keyHandler func(ctx context.Context, nodeUUID string) ([]byte, error)) *Server {
 	return &Server{
 		getKey: keyHandler,
 	}
 }
 
 // Seal encrypts the incoming data.
-func (srv *Server) Seal(_ context.Context, req *kms.Request) (*kms.Response, error) {
+func (srv *Server) Seal(ctx context.Context, req *kms.Request) (*kms.Response, error) {
 	time.Sleep(time.Second)
 
-	key, err := srv.getKey(req.NodeUuid)
+	key, err := srv.getKey(ctx, req.NodeUuid)
 	if err != nil {
 		key, err = getRandomAESKey()
 		if err != nil {
@@ -73,10 +73,10 @@ func (srv *Server) Seal(_ context.Context, req *kms.Request) (*kms.Response, err
 }
 
 // Unseal decrypts the incoming data.
-func (srv *Server) Unseal(_ context.Context, req *kms.Request) (*kms.Response, error) {
+func (srv *Server) Unseal(ctx context.Context, req *kms.Request) (*kms.Response, error) {
 	time.Sleep(time.Second)
 
-	key, err := srv.getKey(req.NodeUuid)
+	key, err := srv.getKey(ctx, req.NodeUuid)
 	if err != nil {
 		key, err = getRandomAESKey()
 		if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -31,7 +31,7 @@ func (suite *ServerSuite) TestSealUnseal() {
 	_, err = io.ReadFull(rand.Reader, passphrase)
 	suite.Require().NoError(err)
 
-	srv := server.NewServer(func(nodeUUID string) ([]byte, error) {
+	srv := server.NewServer(func(_ context.Context, nodeUUID string) ([]byte, error) {
 		if nodeUUID != "abcd" {
 			return nil, fmt.Errorf("unknown node %s", nodeUUID)
 		}
@@ -75,7 +75,7 @@ func (suite *ServerSuite) TestInvalidInputs() {
 	_, err = io.ReadFull(rand.Reader, passphrase)
 	suite.Require().NoError(err)
 
-	srv := server.NewServer(func(nodeUUID string) ([]byte, error) {
+	srv := server.NewServer(func(_ context.Context, nodeUUID string) ([]byte, error) {
 		if nodeUUID != "abcd" {
 			return nil, fmt.Errorf("unknown node %s", nodeUUID)
 		}


### PR DESCRIPTION
Context can be useful for more complicated implementations of the key handler.