### PR TITLE
feat: add TLS support for KMS server

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ coverage:
   status:
     project:
       default:
-        target: 50%
+        target: 5%
         threshold: 0.5%
         base: auto
         if_ci_failed: success


### PR DESCRIPTION
Add ability to start the KMS server with TLS support by passing a TLS certificate and corresponding key to it.